### PR TITLE
Restore documented behaviour when running image without a command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY ./requirements-server.txt /srv/requirements.txt
 RUN pip install --no-cache-dir -U pip
 RUN pip install --no-cache-dir -r /srv/requirements.txt
 
+COPY ./demo_server.py /srv/demo_server.py
 COPY ./server.py /srv/server.py
 COPY ./synthesizer.py /srv/synthesizer.py
 COPY ./hparam.py /srv/hparam.py
@@ -32,3 +33,6 @@ RUN wget -q https://www.softcatala.org/pub/softcatala/catotron-models/upc_pau_ta
 RUN wget -q https://www.softcatala.org/pub/softcatala/catotron-models/melgan_onapau_catotron.pt
 
 WORKDIR /srv
+
+ENTRYPOINT [ "python" ]
+CMD [ "demo_server.py" ]


### PR DESCRIPTION
In [PR#2](https://github.com/CollectivaT-dev/catotron-cpu/pull/2) the ENTRYPOINT was removed, which breaks [the documented behaviour](https://github.com/CollectivaT-dev/catotron-cpu/blob/master/README.md#docker). This will allow again running the image without a command.

Using ENTRYPOINT and COMMAND allows to easily override the python application to run whilst keeping the old behaviour.